### PR TITLE
added note about mysql container memory hog

### DIFF
--- a/markdown/build-deploy.md
+++ b/markdown/build-deploy.md
@@ -45,6 +45,9 @@ Dockerized DB setup:
  > Note: Creation and deployment by Dockerfile is only required the first time!  
  Use ```docker start ls-db``` from here on.
 
+ > Another note: if the MySQL container occupies a lot of memory, try adding a --ulimit flag to the run command like so: ```
+ docker run --ulimit nofile=262144:262144 --platform linux/x86_64 --name=ls-db -p 3453:3306 -d ls-db:Dockerfile``` (taken from <https://github.com/docker-library/mysql/issues/579#issuecomment-519495808>)
+
 ### Lobby Service
 
 Select one of the provided build profiles, depending on your deployment context:


### PR DESCRIPTION
I had an issue with the MySQL container occupying way too much memory (16G) when deployed as-is. Managed to fix it with adding a ulimit flag to docker run command (see https://github.com/docker-library/mysql/issues/579#issuecomment-519495808), for which I added a note in deployment docs.