### PR TITLE
Fixed small link in documentation

### DIFF
--- a/markdown/api.md
+++ b/markdown/api.md
@@ -10,7 +10,7 @@ Structured representation of the Lobby Service's REST resources and offered acce
 
 Quick navigation:
 
- * [/api/online](#online)
+ * [/api/online](#debugging)
  * [/api/users](#users) and subresource
  * [/api/gameservice](#game-services) and subresource
  * [/api/sessions](#sessions) and subresource


### PR DESCRIPTION
Fixed the broken `/api/online` link in the documentation.